### PR TITLE
Set up some default logging in the runner

### DIFF
--- a/cmd/fynedesk_runner/log.go
+++ b/cmd/fynedesk_runner/log.go
@@ -9,7 +9,11 @@ import (
 )
 
 func logPath() string {
-	cacheDir := filepath.Join(systemLogDir(), "fyne", "io.fyne.fynedesk")
+	return logPathRelativeTo(systemLogDir())
+}
+
+func logPathRelativeTo(parent string) string {
+	cacheDir := filepath.Join(parent, "fyne", "io.fyne.fynedesk")
 	err := os.MkdirAll(cacheDir, 0700)
 	if err != nil {
 		fyne.LogError("Could not create log directory", err)

--- a/cmd/fynedesk_runner/log.go
+++ b/cmd/fynedesk_runner/log.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"fyne.io/fyne"
+)
+
+func logPath() string {
+	cacheDir := filepath.Join(systemLogDir(), "fyne", "io.fyne.fynedesk")
+	err := os.MkdirAll(cacheDir, 0700)
+	if err != nil {
+		fyne.LogError("Could not create log directory", err)
+	}
+
+	return filepath.Join(cacheDir, "fynedesk.log")
+}
+
+// openLogWriter returns a stream for stdOut and stdErr of the process we run
+func openLogWriter() (io.WriteCloser, io.WriteCloser) {
+	f, err := os.Create(logPath())
+	if err != nil {
+		fyne.LogError("Unable to open log file", err)
+		return os.Stdout, os.Stderr
+	}
+
+	return f, f
+}

--- a/cmd/fynedesk_runner/log_darwin.go
+++ b/cmd/fynedesk_runner/log_darwin.go
@@ -1,0 +1,13 @@
+// +build darwin
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func systemLogDir() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, "Library", "Logs")
+}

--- a/cmd/fynedesk_runner/log_test.go
+++ b/cmd/fynedesk_runner/log_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testLogDir() string {
+	return filepath.Join("testdata", "cache")
+}
+
+func TestLogPath(t *testing.T) {
+	path := logPathRelativeTo(testLogDir())
+
+	assert.Equal(t, "testdata/cache/fyne/io.fyne.fynedesk/fynedesk.log", path)
+}

--- a/cmd/fynedesk_runner/log_unix.go
+++ b/cmd/fynedesk_runner/log_unix.go
@@ -1,0 +1,13 @@
+// +build !darwin,!windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func systemLogDir() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".cache")
+}

--- a/cmd/fynedesk_runner/log_windows.go
+++ b/cmd/fynedesk_runner/log_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func systemLogDir() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, "AppData", "Local")
+}

--- a/cmd/fynedesk_runner/main.go
+++ b/cmd/fynedesk_runner/main.go
@@ -13,8 +13,7 @@ func main() {
 	for {
 		exe := exec.Command(runCmd)
 		exe.Env = append(os.Environ(), "FYNE_DESK_RUNNER=1")
-		exe.Stdout = os.Stdout
-		exe.Stderr = os.Stderr
+		exe.Stdout, exe.Stderr = openLogWriter()
 		err := exe.Run()
 		if err == nil {
 			return


### PR DESCRIPTION
Attempts to use system locations for the log file.
If you run the fynedesk app directly it will still log to console.