### PR TITLE
Wait for all clients to shut down before we exit

### DIFF
--- a/internal/ui/widgetpanel.go
+++ b/internal/ui/widgetpanel.go
@@ -131,7 +131,7 @@ func (w *widgetPanel) showAccountMenu(from fyne.CanvasObject) {
 
 	root := w.desk.(*desktop).primaryWin
 	items = append(items, fyne.NewMenuItem(closeLabel, func() {
-		root.Close()
+		w.desk.WindowManager().Close()
 	}))
 
 	popup := widget.NewPopUpMenu(fyne.NewMenu("Account", items...), root.Canvas())


### PR DESCRIPTION
We should have been closing all windows - a bug in WidgetPanel hid that, fixed

W now give windows 10 seconds, then show a notification.
Dialog was an alternative but the fyne dialog API is not easy for us as it relies on an open window (easier with compositor)

Fixes #92