### PR TITLE
Refactor border logic to border

### DIFF
--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -451,7 +451,7 @@ func (f *frame) mouseMotion(x, y int16) {
 		if obj.(desktop.Cursorable).Cursor() == wm.CloseCursor {
 			cursor = x11.CloseCursor
 		}
-	} else if uint16(y) > titleHeight {
+	} else if uint16(relY) > titleHeight {
 		if !f.client.Maximized() && !f.client.Fullscreened() && !windowSizeFixed(f.client.wm.X(), f.client.win) {
 			cursor = f.lookupResizeCursor(relX, relY)
 		}
@@ -476,7 +476,7 @@ func (f *frame) lookupResizeCursor(x, y int16) xproto.Cursor {
 			return x11.ResizeBottomCursor
 		}
 	} else { // center (sides)
-		if x < int16(f.width-cornerSize) {
+		if x < int16(cornerSize) {
 			return x11.ResizeLeftCursor
 		} else if x >= int16(f.width-cornerSize) {
 			return x11.ResizeRightCursor

--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -6,6 +6,7 @@ import (
 	"image"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/tools/playground"
 
@@ -34,6 +35,7 @@ type frame struct {
 	borderTop, borderTopRight xproto.Pixmap
 	borderTopWidth            uint16
 
+	canvas fyne.Canvas
 	client *client
 }
 
@@ -199,7 +201,7 @@ func (f *frame) applyTheme(force bool) {
 
 func (f *frame) checkScale() {
 	titleHeight := x11.TitleHeight(x11.XWin(f.client))
-	if f.height - titleHeight != f.childHeight {
+	if f.height-titleHeight != f.childHeight {
 		f.updateGeometry(f.x, f.y, f.width, f.height, true)
 		f.notifyInnerGeometry()
 	}
@@ -314,6 +316,7 @@ func (f *frame) drawDecoration(pidTop xproto.Pixmap, drawTop xproto.Gcontext, pi
 		canMaximize = false
 	}
 	canvas.SetContent(wm.NewBorder(f.client, f.client.Properties().Icon(), canMaximize))
+	f.canvas = canvas
 
 	heightPix := x11.TitleHeight(x11.XWin(f.client))
 	iconBorderPixWidth := heightPix + x11.BorderWidth(x11.XWin(f.client))*2
@@ -432,41 +435,25 @@ func (f *frame) mouseDrag(x, y int16) {
 }
 
 func (f *frame) mouseMotion(x, y int16) {
-	borderWidth := x11.BorderWidth(x11.XWin(f.client))
-	buttonWidth := x11.ButtonWidth(x11.XWin(f.client))
 	titleHeight := x11.TitleHeight(x11.XWin(f.client))
-
 	relX := x - f.x
 	relY := y - f.y
+
+	obj := wm.FindObjectAtPixelPositionMatching(int(relX), int(relY), f.canvas,
+		func(obj fyne.CanvasObject) bool {
+			_, ok := obj.(desktop.Cursorable)
+			return ok
+		},
+	)
+
 	cursor := x11.DefaultCursor
-	if relY <= int16(titleHeight) { // title bar
-		if relX > int16(borderWidth) && relX <= int16(borderWidth+buttonWidth) {
+	if obj != nil {
+		if obj.(desktop.Cursorable).Cursor() == wm.CloseCursor {
 			cursor = x11.CloseCursor
 		}
-		err := xproto.ChangeWindowAttributesChecked(f.client.wm.Conn(), f.client.id, xproto.CwCursor,
-			[]uint32{uint32(cursor)}).Check()
-		if err != nil {
-			fyne.LogError("Set Cursor Error", err)
-		}
-		return
-	}
-	if f.client.Maximized() || f.client.Fullscreened() || windowSizeFixed(f.client.wm.X(), f.client.win) {
-		return
-	}
-
-	if relY >= int16(f.height-buttonWidth) { // bottom
-		if relX < int16(buttonWidth) {
-			cursor = x11.ResizeBottomLeftCursor
-		} else if relX >= int16(f.width-buttonWidth) {
-			cursor = x11.ResizeBottomRightCursor
-		} else {
-			cursor = x11.ResizeBottomCursor
-		}
-	} else { // center (sides)
-		if relX < int16(f.width-buttonWidth) {
-			cursor = x11.ResizeLeftCursor
-		} else if relX >= int16(f.width-buttonWidth) {
-			cursor = x11.ResizeRightCursor
+	} else if uint16(y) > titleHeight {
+		if !f.client.Maximized() && !f.client.Fullscreened() && !windowSizeFixed(f.client.wm.X(), f.client.win) {
+			cursor = f.lookupResizeCursor(relX, relY)
 		}
 	}
 
@@ -475,6 +462,28 @@ func (f *frame) mouseMotion(x, y int16) {
 	if err != nil {
 		fyne.LogError("Set Cursor Error", err)
 	}
+}
+
+func (f *frame) lookupResizeCursor(x, y int16) xproto.Cursor {
+	cornerSize := x11.ButtonWidth(x11.XWin(f.client))
+
+	if y >= int16(f.height-cornerSize) { // bottom
+		if x < int16(cornerSize) {
+			return x11.ResizeBottomLeftCursor
+		} else if x >= int16(f.width-cornerSize) {
+			return x11.ResizeBottomRightCursor
+		} else {
+			return x11.ResizeBottomCursor
+		}
+	} else { // center (sides)
+		if x < int16(f.width-cornerSize) {
+			return x11.ResizeLeftCursor
+		} else if x >= int16(f.width-cornerSize) {
+			return x11.ResizeRightCursor
+		}
+	}
+
+	return x11.DefaultCursor
 }
 
 func (f *frame) mousePress(x, y int16) {

--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -529,8 +529,6 @@ func (f *frame) mousePress(x, y int16) {
 }
 
 func (f *frame) mouseRelease(x, y int16) {
-	borderWidth := x11.BorderWidth(x11.XWin(f.client))
-	buttonWidth := x11.ButtonWidth(x11.XWin(f.client))
 	titleHeight := x11.TitleHeight(x11.XWin(f.client))
 
 	relX := x - f.x
@@ -539,26 +537,18 @@ func (f *frame) mouseRelease(x, y int16) {
 	if relY > barYMax {
 		return
 	}
-	if relX >= int16(borderWidth) && relX < int16(borderWidth+buttonWidth) {
-		f.client.Close()
-	}
-	if relX >= int16(borderWidth)+int16(theme.Padding())+int16(buttonWidth) &&
-		relX < int16(borderWidth)+int16(theme.Padding()*2)+int16(buttonWidth*2) {
-		if f.client.Maximized() {
-			f.client.Unmaximize()
-		} else {
-			f.client.Maximize()
-		}
-	} else if relX >= int16(borderWidth)+int16(theme.Padding()*2)+int16(buttonWidth*2) &&
-		relX < int16(borderWidth)+int16(theme.Padding()*2)+int16(buttonWidth*3) {
-		f.client.Iconify()
-	}
 
-	f.resizeBottom = false
-	f.resizeLeft = false
-	f.resizeRight = false
-	f.moveOnly = false
-	f.updateGeometry(f.x, f.y, f.width, f.height, false)
+	obj := wm.FindObjectAtPixelPositionMatching(int(relX), int(relY), f.canvas,
+		func(obj fyne.CanvasObject) bool {
+			_, ok := obj.(fyne.Tappable)
+			return ok
+		},
+	)
+
+	if obj == nil {
+		return
+	}
+	obj.(fyne.Tappable).Tapped(&fyne.PointEvent{})
 }
 
 // Notify the child window that it's geometry has changed to update menu positions etc.

--- a/wm/border.go
+++ b/wm/border.go
@@ -32,8 +32,13 @@ func NewBorder(win fynedesk.Window, icon fyne.Resource, canMaximize bool) fyne.C
 		}
 	}
 
-	exit := newCloseButton()
-	max := widget.NewButtonWithIcon("", wmTheme.MaximizeIcon, func() {})
+	max := widget.NewButtonWithIcon("", wmTheme.MaximizeIcon, func() {
+		if win.Maximized() {
+			win.Unmaximize()
+		} else {
+			win.Maximize()
+		}
+	})
 	if win.Maximized() {
 		max.Icon = theme.ViewRestoreIcon()
 	}
@@ -41,9 +46,11 @@ func NewBorder(win fynedesk.Window, icon fyne.Resource, canMaximize bool) fyne.C
 		max.Disable()
 	}
 	titleBar := newColoredHBox(win.Focused(), makeFiller(0),
-		exit,
+		newCloseButton(win),
 		max,
-		widget.NewButtonWithIcon("", wmTheme.IconifyIcon, func() {}),
+		widget.NewButtonWithIcon("", wmTheme.IconifyIcon, func() {
+			win.Iconify()
+		}),
 		widget.NewLabel(win.Properties().Title()),
 		layout.NewSpacer())
 

--- a/wm/border.go
+++ b/wm/border.go
@@ -32,8 +32,7 @@ func NewBorder(win fynedesk.Window, icon fyne.Resource, canMaximize bool) fyne.C
 		}
 	}
 
-	exit := widget.NewButtonWithIcon("", theme.CancelIcon(), func() {})
-	exit.Style = widget.PrimaryButton
+	exit := newCloseButton()
 	max := widget.NewButtonWithIcon("", wmTheme.MaximizeIcon, func() {})
 	if win.Maximized() {
 		max.Icon = theme.ViewRestoreIcon()

--- a/wm/button.go
+++ b/wm/button.go
@@ -1,0 +1,29 @@
+package wm
+
+import (
+	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+)
+
+const (
+	// CloseCursor is the mouse cursor that indicates a close action
+	CloseCursor desktop.Cursor = iota + desktop.VResizeCursor // add to the end of the fyne list
+)
+
+type closeButton struct {
+	widget.Button
+}
+
+func (c *closeButton) Cursor() desktop.Cursor {
+	return CloseCursor
+}
+
+func newCloseButton() *closeButton {
+	b := &closeButton{}
+	b.ExtendBaseWidget(b)
+	b.Icon = theme.CancelIcon()
+	b.Style = widget.PrimaryButton
+
+	return b
+}

--- a/wm/button.go
+++ b/wm/button.go
@@ -4,6 +4,7 @@ import (
 	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
+	"fyne.io/fynedesk"
 )
 
 const (
@@ -19,9 +20,13 @@ func (c *closeButton) Cursor() desktop.Cursor {
 	return CloseCursor
 }
 
-func newCloseButton() *closeButton {
+func newCloseButton(win fynedesk.Window) *closeButton {
 	b := &closeButton{}
 	b.ExtendBaseWidget(b)
+	b.OnTapped = func() {
+		win.Close()
+	}
+
 	b.Icon = theme.CancelIcon()
 	b.Style = widget.PrimaryButton
 

--- a/wm/util.go
+++ b/wm/util.go
@@ -1,0 +1,133 @@
+package wm
+
+import (
+	"math"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/test"
+)
+
+// FindObjectAtPixelPositionMatching looks for objects in the given canvas that are under pixel
+// position at x, y. Objects must match the criteria in 'fn' and the first match will be returned.
+func FindObjectAtPixelPositionMatching(x, y int, c fyne.Canvas, fn func(fyne.CanvasObject) bool) fyne.CanvasObject {
+	pos := fyne.NewPos(unscaleInt(c, x), unscaleInt(c, y))
+	obj, _ := findObjectAtPositionMatching(pos, fn, c.Content())
+	return obj
+}
+
+// some internal Fyne functions that we find very useful as we have to drive the frame UI
+
+func findObjectAtPositionMatching(mouse fyne.Position, matches func(object fyne.CanvasObject) bool,
+	overlay fyne.CanvasObject, roots ...fyne.CanvasObject) (fyne.CanvasObject, fyne.Position) {
+	var found fyne.CanvasObject
+	var foundPos fyne.Position
+
+	findFunc := func(walked fyne.CanvasObject, pos fyne.Position, clipPos fyne.Position, clipSize fyne.Size) bool {
+		if !walked.Visible() {
+			return false
+		}
+
+		if mouse.X < clipPos.X || mouse.Y < clipPos.Y {
+			return false
+		}
+
+		if mouse.X >= clipPos.X+clipSize.Width || mouse.Y >= clipPos.Y+clipSize.Height {
+			return false
+		}
+
+		if mouse.X < pos.X || mouse.Y < pos.Y {
+			return false
+		}
+
+		if mouse.X >= pos.X+walked.Size().Width || mouse.Y >= pos.Y+walked.Size().Height {
+			return false
+		}
+
+		if matches(walked) {
+			found = walked
+			foundPos = fyne.NewPos(mouse.X-pos.X, mouse.Y-pos.Y)
+		}
+		return false
+	}
+
+	if overlay != nil {
+		walkVisibleObjectTree(overlay, findFunc, nil)
+	} else {
+		for _, root := range roots {
+			if root == nil {
+				continue
+			}
+			walkVisibleObjectTree(root, findFunc, nil)
+			if found != nil {
+				break
+			}
+		}
+	}
+
+	return found, foundPos
+}
+
+func unscaleInt(c fyne.Canvas, v int) int {
+	switch c.Scale() {
+	case 1.0:
+		return v
+	default:
+		return int(float32(v) / c.Scale())
+	}
+}
+
+func walkObjectTree(
+	obj fyne.CanvasObject,
+	parent fyne.CanvasObject,
+	offset, clipPos fyne.Position,
+	clipSize fyne.Size,
+	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
+	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+	requireVisible bool,
+) bool {
+	if requireVisible && !obj.Visible() {
+		return false
+	}
+	pos := obj.Position().Add(offset)
+
+	var children []fyne.CanvasObject
+	switch co := obj.(type) {
+	case *fyne.Container:
+		children = co.Objects
+	case fyne.Widget:
+		children = test.WidgetRenderer(co).Objects()
+
+		if _, ok := obj.(fyne.Scrollable); ok {
+			clipPos = pos
+			clipSize = obj.Size()
+		}
+	}
+
+	if beforeChildren != nil {
+		if beforeChildren(obj, pos, clipPos, clipSize) {
+			return true
+		}
+	}
+
+	cancelled := false
+	for _, child := range children {
+		if walkObjectTree(child, obj, pos, clipPos, clipSize, beforeChildren, afterChildren, requireVisible) {
+			cancelled = true
+			break
+		}
+	}
+
+	if afterChildren != nil {
+		afterChildren(obj, parent)
+	}
+	return cancelled
+}
+
+func walkVisibleObjectTree(
+	obj fyne.CanvasObject,
+	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
+	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+) bool {
+	clipSize := fyne.NewSize(math.MaxInt32, math.MaxInt32)
+	return walkObjectTree(obj, nil, fyne.NewPos(0, 0), fyne.NewPos(0, 0), clipSize, beforeChildren, afterChildren, true)
+}


### PR DESCRIPTION
Removing X specific maths heavy code and instead use the Fyne border code better.
This moves cursor and tap handling into Fyne code (/wm/border.go) as you would have expected.