### PR TITLE
Fix for Java Swing windows being 0 sized

### DIFF
--- a/internal/x11/wm/events.go
+++ b/internal/x11/wm/events.go
@@ -291,7 +291,7 @@ func (x *x11WM) handleScreenChange(timestamp xproto.Timestamp) {
 		return
 	}
 	desk.Screens().RefreshScreens()
-	x.configureRoots(x.x.RootWin())
+	x.configureRoots()
 }
 
 func (x *x11WM) handleStateActionRequest(ev xproto.ClientMessageEvent, removeState func(), addState func(), toggleCheck bool) {


### PR DESCRIPTION
This was an issue when we had just 1 screen
because the re-configure did not arrive with only a single root

Fixes #114 