### PR TITLE
Update and improve Makefile to use better install practices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-# If DESTDIR is not provided, we default to /usr/local if it exists and if it doesn't we fall back /usr.
+# If PREFIX isn't provided, we check for /usr/local and use that if it exists. Otherwice we fall back to using /usr.
 ifneq ("$(wildcard /usr/local)","")
-DESTDIR ?= /usr/local
+PREFIX ?= /usr/local
 else
-DESTDIR ?= /usr
+PREFIX ?= /usr
 endif
 
 build:
@@ -10,7 +10,6 @@ build:
 	go build ./cmd/fynedesk || (echo "Failed to build fynedesk"; exit 1)
 
 install:
-	cp cmd/fynedesk_runner/fynedesk_runner $(DESTDIR)/bin
-	cp cmd/fynedesk/fynedesk $(DESTDIR)$(PREFIX)/bin
-	cp fynedesk.desktop $(DESTDIR)/share/xsessions
-
+	install -Dm00755 fynedesk_runner $(DESTDIR)$(PREFIX)/bin/fynedesk_runner
+	install -Dm00755 fynedesk $(DESTDIR)$(PREFIX)/bin/fynedesk
+	install -Dm00644 fynedesk.desktop $(DESTDIR)$(PREFIX)/share/xsessions/fynedesk.desktop


### PR DESCRIPTION
The following changes have been made to improve it:
- We follow common practice and set PREFIX, not DESTDIR.
- Go builds into current directory. Use correct install rules for that (I have honestly no idea why it worked before).
- We now use the install command with correct file permissions for binaries and text files and option to create directories if not existing.

The result of all this is that the Makefile is now complying with building `fynedesk` inside `solbuild`, the containerized packaging solution for Solus. I have thus successfully built and installed a `fynedesk` package built for solus as `fynedesk-0.1.3-1-1-x86_64.eopkg`. Not in any repository, but great nun the less :)

For anyone interested, here is the package.yml file for it:
```yml
name       : fynedesk
version    : 0.1.3
release    : 1
source     :
    - git|https://github.com/Jacalz/fynedesk.git : 2f5424855716b229256e0a399f25aea57be5270e
license    : BSD-3-Clause
component  : desktop.environment
summary    : A full desktop environment for Linux/Unix using Fyne.
description: |
    FyneDesk is an easy to use Linux/Unix desktop environment following material design. It is build using the Fyne toolkit and is designed to be easy to use as well as easy to develop. We use the Go language and welcome any contributions or feedback for the project.
networking : yes
builddeps  :
    - pkgconfig(xxf86vm)
    - pkgconfig(xcursor)
    - pkgconfig(xi)
    - pkgconfig(xinerama)
    - pkgconfig(xrandr)
    - golang
    - mesalib-devel
build      : |
    %make
install    : |
    %make_install
```