### PR TITLE
Filter background image selction and default to pictures dir

### DIFF
--- a/internal/ui/settings_ui.go
+++ b/internal/ui/settings_ui.go
@@ -381,10 +381,10 @@ func getPicturesDir() (fyne.ListableURI, error) {
 	if _, err := exec.LookPath(xdg); err == nil {
 		cmd := exec.Command(xdg, "PICTURES")
 
-		loc, err := cmd.Output()
-		if err == nil {
-			loc = loc[:len(loc)-1] // Remove \n at the end
-			uri := storage.NewFileURI(string(loc))
+		out, err := cmd.Output()
+		location := string(out[:len(out)-1]) // Remove \n at the end
+		if err == nil && location != home {
+			uri := storage.NewFileURI(location)
 			return storage.ListerForURI(uri)
 		}
 	}


### PR DESCRIPTION
This commit changes the starting location of the file dialog that selects the background to try to use the pictures folder.
It also filters out files to only show jpg/jpeg, png and svg.

![image](https://user-images.githubusercontent.com/25466657/97894640-06d39800-1d33-11eb-9c82-b6215a49f3fd.png)
