### PR TITLE
Add a way of running in embedded X window using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ uninstall:
 	-rm $(DESTDIR)$(PREFIX)/bin/fynedesk_runner
 	-rm $(DESTDIR)$(PREFIX)/bin/fynedesk
 	-rm $(DESTDIR)$(PREFIX)/share/xsessions/fynedesk.desktop
+
+run:
+	// This needs to run with -j2 (make run -j2) to run concurrently
+	DISPLAY=:0 Xephyr :1 -screen 1280x720 &
+	DISPLAY=:1 fynedesk

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ uninstall:
 	-rm $(DESTDIR)$(PREFIX)/bin/fynedesk
 	-rm $(DESTDIR)$(PREFIX)/share/xsessions/fynedesk.desktop
 
-run:
-	// This needs to run with -j2 (make run -j2) to run concurrently
+embed:
 	DISPLAY=:0 Xephyr :1 -screen 1280x720 &
 	DISPLAY=:1 fynedesk

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once installed you could set `$GOPATH/fynedesk` as your window manager (usually
 using .xinitrc).
 You can also run it in an embedded X window for testing using:
 
-    make run -j2
+    make embed
 
 It should look like this:
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Once installed you could set `$GOPATH/fynedesk` as your window manager (usually
 using .xinitrc).
 You can also run it in an embedded X window for testing using:
 
-    DISPLAY=:0 Xephyr :1 -screen 1280x720 &
-    DISPLAY=:1 fynedesk
+    make run -j2
 
 It should look like this:
 


### PR DESCRIPTION
I am tired of copy-and-pasting the lines from the README whenever I want to do this. Now we can just run `make run -j2` to do it :)