### PR TITLE
Use a queue to configure windows on move/resize.

### DIFF
--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -185,7 +185,7 @@ func (c *client) NotifyBorderChange() {
 }
 
 func (c *client) NotifyGeometry(x int, y int, width uint, height uint) {
-	c.frame.updateGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
+	c.frame.queueGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
 }
 
 func (c *client) NotifyFullscreen() {
@@ -224,6 +224,7 @@ func (c *client) NotifyMouseRelease(x, y int16, b xproto.Button) {
 }
 
 func (c *client) NotifyMoveResizeEnded() {
+	c.frame.closeQueueGeometry()
 	c.frame.notifyInnerGeometry()
 }
 

--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -184,11 +184,7 @@ func (c *client) NotifyBorderChange() {
 	}
 }
 
-func (c *client) NotifyGeometry(x int, y int, width uint, height uint, queue bool) {
-	if queue {
-		c.frame.queueGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
-		return
-	}
+func (c *client) NotifyGeometry(x int, y int, width uint, height uint) {
 	c.frame.updateGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
 }
 
@@ -228,7 +224,7 @@ func (c *client) NotifyMouseRelease(x, y int16, b xproto.Button) {
 }
 
 func (c *client) NotifyMoveResizeEnded() {
-	c.frame.closeQueueGeometry()
+	c.frame.endConfigureLoop()
 	c.frame.notifyInnerGeometry()
 }
 
@@ -254,6 +250,10 @@ func (c *client) NotifyUnMaximize() {
 	c.frame.unmaximizeApply()
 	x11.WindowExtendedHintsRemove(c.wm.X(), c.win, "_NET_WM_STATE_MAXIMIZED_VERT")
 	x11.WindowExtendedHintsRemove(c.wm.X(), c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
+}
+
+func (c *client) QueueMoveResizeGeometry(x int, y int, width uint, height uint) {
+	c.frame.queueGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
 }
 
 func (c *client) RaiseAbove(win fynedesk.Window) {

--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -184,8 +184,12 @@ func (c *client) NotifyBorderChange() {
 	}
 }
 
-func (c *client) NotifyGeometry(x int, y int, width uint, height uint) {
-	c.frame.queueGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
+func (c *client) NotifyGeometry(x int, y int, width uint, height uint, queue bool) {
+	if queue {
+		c.frame.queueGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
+		return
+	}
+	c.frame.updateGeometry(int16(x), int16(y), uint16(width), uint16(height), true)
 }
 
 func (c *client) NotifyFullscreen() {

--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -484,7 +484,7 @@ func (f *frame) maximizeApply() {
 }
 
 func (f *frame) mouseDrag(x, y int16) {
-	if f.client.Fullscreened() {
+	if f.client.Maximized() || f.client.Fullscreened() {
 		return
 	}
 	moveDeltaX := x - f.mouseX
@@ -492,13 +492,6 @@ func (f *frame) mouseDrag(x, y int16) {
 	f.mouseX = x
 	f.mouseY = y
 	if moveDeltaX == 0 && moveDeltaY == 0 {
-		return
-	}
-	if f.client.Maximized() {
-		if uint16(moveDeltaX) > x11.ButtonWidth(x11.XWin(f.client)) ||
-			uint16(moveDeltaY) > x11.TitleHeight(x11.XWin(f.client)) {
-			f.client.Unmaximize()
-		}
 		return
 	}
 

--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -484,7 +484,7 @@ func (f *frame) maximizeApply() {
 }
 
 func (f *frame) mouseDrag(x, y int16) {
-	if f.client.Maximized() || f.client.Fullscreened() {
+	if f.client.Fullscreened() {
 		return
 	}
 	moveDeltaX := x - f.mouseX
@@ -492,6 +492,13 @@ func (f *frame) mouseDrag(x, y int16) {
 	f.mouseX = x
 	f.mouseY = y
 	if moveDeltaX == 0 && moveDeltaY == 0 {
+		return
+	}
+	if f.client.Maximized() {
+		if uint16(moveDeltaX) > x11.ButtonWidth(x11.XWin(f.client)) ||
+			uint16(moveDeltaY) > x11.TitleHeight(x11.XWin(f.client)) {
+			f.client.Unmaximize()
+		}
 		return
 	}
 
@@ -675,7 +682,6 @@ func (f *frame) mousePress(x, y int16, b xproto.Button) {
 }
 
 func (f *frame) mouseRelease(x, y int16, b xproto.Button) {
-	f.endConfigureLoop()
 	if b != xproto.ButtonIndex1 {
 		return
 	}

--- a/internal/x11/wm/desk.go
+++ b/internal/x11/wm/desk.go
@@ -449,16 +449,16 @@ func (x *x11WM) configureWindow(win xproto.Window, ev xproto.ConfigureRequestEve
 
 			if c.Properties().Decorated() {
 				if !c.Fullscreened() {
-					c.NotifyGeometry(x, y, uint(ev.Width+(borderWidth*2)), uint(ev.Height+borderWidth+titleHeight), false)
+					c.NotifyGeometry(x, y, uint(ev.Width+(borderWidth*2)), uint(ev.Height+borderWidth+titleHeight))
 				} else {
-					c.NotifyGeometry(x, y, uint(ev.Width), uint(ev.Height), false)
+					c.NotifyGeometry(x, y, uint(ev.Width), uint(ev.Height))
 				}
 			} else {
 				if ev.X == 0 && ev.Y == 0 {
 					ev.X = int16(x)
 					ev.Y = int16(y)
 				}
-				c.NotifyGeometry(int(ev.X), int(ev.Y), uint(ev.Width), uint(ev.Height), false)
+				c.NotifyGeometry(int(ev.X), int(ev.Y), uint(ev.Width), uint(ev.Height))
 			}
 		}
 		return

--- a/internal/x11/wm/desk.go
+++ b/internal/x11/wm/desk.go
@@ -42,6 +42,8 @@ type x11WM struct {
 	x                       *xgbutil.XUtil
 	framedExisting          bool
 	moveResizing            bool
+	moveResizingX           int
+	moveResizingY           int
 	moveResizingStartX      int16
 	moveResizingStartY      int16
 	moveResizingLastX       int16

--- a/internal/x11/wm/desk.go
+++ b/internal/x11/wm/desk.go
@@ -446,16 +446,16 @@ func (x *x11WM) configureWindow(win xproto.Window, ev xproto.ConfigureRequestEve
 
 			if c.Properties().Decorated() {
 				if !c.Fullscreened() {
-					c.NotifyGeometry(x, y, uint(ev.Width+(borderWidth*2)), uint(ev.Height+borderWidth+titleHeight))
+					c.NotifyGeometry(x, y, uint(ev.Width+(borderWidth*2)), uint(ev.Height+borderWidth+titleHeight), false)
 				} else {
-					c.NotifyGeometry(x, y, uint(ev.Width), uint(ev.Height))
+					c.NotifyGeometry(x, y, uint(ev.Width), uint(ev.Height), false)
 				}
 			} else {
 				if ev.X == 0 && ev.Y == 0 {
 					ev.X = int16(x)
 					ev.Y = int16(y)
 				}
-				c.NotifyGeometry(int(ev.X), int(ev.Y), uint(ev.Width), uint(ev.Height))
+				c.NotifyGeometry(int(ev.X), int(ev.Y), uint(ev.Width), uint(ev.Height), false)
 			}
 		}
 		return

--- a/internal/x11/wm/events.go
+++ b/internal/x11/wm/events.go
@@ -280,7 +280,8 @@ func (x *x11WM) handlePropertyChange(ev xproto.PropertyNotifyEvent) {
 		c.Refresh()
 	case "WM_NORMAL_HINTS":
 		// Force a reconfigure to make sure the client is constrained to the new size hints
-		c.NotifyGeometry(c.Geometry())
+		x, y, w, h := c.Geometry()
+		c.NotifyGeometry(x, y, w, h, false)
 	case "_MOTIF_WM_HINTS":
 		c.NotifyBorderChange()
 	}
@@ -402,5 +403,5 @@ func (x *x11WM) moveResize(moveX, moveY int16, c x11.XWin) {
 	}
 	x.moveResizingLastX = moveX
 	x.moveResizingLastY = moveY
-	c.NotifyGeometry(x.moveResizingX, x.moveResizingY, uint(w), uint(h))
+	c.NotifyGeometry(x.moveResizingX, x.moveResizingY, uint(w), uint(h), true)
 }

--- a/internal/x11/wm/events.go
+++ b/internal/x11/wm/events.go
@@ -281,7 +281,7 @@ func (x *x11WM) handlePropertyChange(ev xproto.PropertyNotifyEvent) {
 	case "WM_NORMAL_HINTS":
 		// Force a reconfigure to make sure the client is constrained to the new size hints
 		x, y, w, h := c.Geometry()
-		c.NotifyGeometry(x, y, w, h, false)
+		c.NotifyGeometry(x, y, w, h)
 	case "_MOTIF_WM_HINTS":
 		c.NotifyBorderChange()
 	}
@@ -403,5 +403,5 @@ func (x *x11WM) moveResize(moveX, moveY int16, c x11.XWin) {
 	}
 	x.moveResizingLastX = moveX
 	x.moveResizingLastY = moveY
-	c.NotifyGeometry(x.moveResizingX, x.moveResizingY, uint(w), uint(h), true)
+	c.QueueMoveResizeGeometry(x.moveResizingX, x.moveResizingY, uint(w), uint(h))
 }

--- a/internal/x11/xwin.go
+++ b/internal/x11/xwin.go
@@ -24,7 +24,7 @@ type XWin interface {
 	SettingsChanged()
 
 	NotifyBorderChange()
-	NotifyGeometry(int, int, uint, uint)
+	NotifyGeometry(int, int, uint, uint, bool)
 	NotifyMoveResizeEnded()
 
 	NotifyMaximize()

--- a/internal/x11/xwin.go
+++ b/internal/x11/xwin.go
@@ -24,7 +24,7 @@ type XWin interface {
 	SettingsChanged()
 
 	NotifyBorderChange()
-	NotifyGeometry(int, int, uint, uint, bool)
+	NotifyGeometry(int, int, uint, uint)
 	NotifyMoveResizeEnded()
 
 	NotifyMaximize()
@@ -38,4 +38,6 @@ type XWin interface {
 	NotifyMouseMotion(int16, int16)
 	NotifyMousePress(int16, int16, xproto.Button)
 	NotifyMouseRelease(int16, int16, xproto.Button)
+
+	QueueMoveResizeGeometry(int, int, uint, uint)
 }

--- a/test/window_x11.go
+++ b/test/window_x11.go
@@ -30,7 +30,7 @@ func (w *Window) NotifyBorderChange() {
 }
 
 // NotifyGeometry is called when the window is instructed to change it's geometry
-func (w *Window) NotifyGeometry(int, int, uint, uint, bool) {
+func (w *Window) NotifyGeometry(int, int, uint, uint) {
 	// no-op
 }
 

--- a/test/window_x11.go
+++ b/test/window_x11.go
@@ -89,6 +89,11 @@ func (w *Window) NotifyMouseRelease(int16, int16, xproto.Button) {
 	// no-op
 }
 
+// QueueMoveResizeGeometry is called when a MoveResize event reports new geometry
+func (w *Window) QueueMoveResizeGeometry(int, int, uint, uint) {
+	// no-op
+}
+
 // Refresh is called when the window should update with new border state
 func (w *Window) Refresh() {
 	// no-op

--- a/test/window_x11.go
+++ b/test/window_x11.go
@@ -30,7 +30,7 @@ func (w *Window) NotifyBorderChange() {
 }
 
 // NotifyGeometry is called when the window is instructed to change it's geometry
-func (w *Window) NotifyGeometry(int, int, uint, uint) {
+func (w *Window) NotifyGeometry(int, int, uint, uint, bool) {
 	// no-op
 }
 


### PR DESCRIPTION
Don't propogate mouse clicks on moveresize events
Don't send a configure after moveresize cancel

Fixes #163 and #119 