### PR TITLE
Improved static ci

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,17 +6,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1.5.0
       with:
-        go-version: '^1.15.x'     
+        go-version: '1.16.x'     
 
     - name: Get dependencies
       run: |
         sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
-        GO111MODULE=off go get golang.org/x/tools/cmd/goimports                               
-        GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
-        GO111MODULE=off go get golang.org/x/lint/golint
-        GO111MODULE=off go get honnef.co/go/tools/cmd/staticcheck
+        go install golang.org/x/tools/cmd/goimports@latest
+        go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+        go install golang.org/x/lint/golint@latest
+        go install honnef.co/go/tools/cmd/staticcheck@v0.1.2
     - name: Cleanup repository
       run: rm -rf vendor/
 
@@ -33,4 +33,4 @@ jobs:
       run: golint -set_exit_status $(go list -tags ci ./...)
 
     - name: Staticcheck
-      run: CGO_ENABLED=1 staticcheck -f stylish ./...
+      run: staticcheck -go 1.12 -f stylish ./...


### PR DESCRIPTION
Basically the same as https://github.com/fyne-io/fyne/pull/1978

This updates the static analysis to use Go 1.16 for the improvements with using go install with a version number (only used for staticcheck for now as it receives a lot of updates and just pulling latest might break us). It also allows it to be used without modifying go.mod (thus not needing to turn off modules each time). Go 1.16 also has a slightly faster linker so the installation and build of the ci tools should be a bit faster.

It also switches to a faster go setup action which is about three times faster while also allowing us to see inline staticcheck reports in PR diffs (cool stuff). Only doing this for static analysis for now as I can't get it to past for the platform tests just yet.
I also made sure to tell staticcheck what Go version we are targeting with potential newer checks not being possible to apply for us.

I plan on getting the platform tests updated for Go 1.16 as well, but I want one or two bug fix releases to land first just in case.