### PR TITLE
Allow fyneterm to be picked up automatically

### DIFF
--- a/internal/icon/fdo.go
+++ b/internal/icon/fdo.go
@@ -542,7 +542,7 @@ func appendAppIfExists(apps []fynedesk.AppData, app fynedesk.AppData) []fynedesk
 func (f *fdoIconProvider) DefaultApps() []fynedesk.AppData {
 	var apps []fynedesk.AppData
 
-	apps = appendAppIfExists(apps, findOneAppFromNames(f, "xfce4-terminal", "gnome-terminal", "org.kde.konsole", "xterm"))
+	apps = appendAppIfExists(apps, findOneAppFromNames(f, "fyneterm", "xfce4-terminal", "gnome-terminal", "org.kde.konsole", "xterm"))
 	apps = appendAppIfExists(apps, findOneAppFromNames(f, "chromium", "google-chrome", "firefox"))
 	apps = appendAppIfExists(apps, findOneAppFromNames(f, "sylpheed", "thunderbird", "evolution"))
 	apps = appendAppIfExists(apps, f.FindAppFromName("gimp"))


### PR DESCRIPTION
This lets the default pinned terminal pick up fyneterm as an option if it is installed on the system.
If it is not, it will fall back to the other common terminals that might exist.