### PR TITLE
Remove unnecessary type convertions

### DIFF
--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -756,7 +756,7 @@ func (f *frame) mouseReleaseWaitForDoubleClick(relX int, relY int) {
 func (f *frame) notifyInnerGeometry() {
 	innerX, innerY, innerW, innerH := f.getInnerWindowCoordinates(f.width, f.height)
 	ev := xproto.ConfigureNotifyEvent{Event: f.client.win, Window: f.client.win, AboveSibling: 0,
-		X: int16(f.x + int16(innerX)), Y: int16(f.y + int16(innerY)), Width: uint16(innerW), Height: uint16(innerH),
+		X: f.x + int16(innerX), Y: f.y + int16(innerY), Width: uint16(innerW), Height: uint16(innerH),
 		BorderWidth: x11.BorderWidth(x11.XWin(f.client)), OverrideRedirect: false}
 	xproto.SendEvent(f.client.wm.Conn(), false, f.client.win, xproto.EventMaskStructureNotify, string(ev.Bytes()))
 }


### PR DESCRIPTION
This commit applies the work done by running `unconvert -apply ./...` on the codebase in order to remove unnecessary conversions. It only happened in two places on the same line, so this very minor PR just fixes that little case :)