### PR TITLE
Switch from fmt.Sprintf to strconv where useful

### DIFF
--- a/internal/icon/fdo.go
+++ b/internal/icon/fdo.go
@@ -3,7 +3,6 @@ package icon // import "fyne.io/fynedesk/internal/icon"
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"image/png"
 	"io/ioutil"
 	"math"
@@ -234,11 +233,9 @@ func fdoClosestSizeIcon(files []os.FileInfo, iconSize int, format string, baseDi
 	var closestMatch string
 	var difference int
 	for _, size := range sizes {
-		sizeDir := ""
+		sizeDir := strconv.Itoa(size)
 		if format == "32x32" {
-			sizeDir = fmt.Sprintf("%dx%d", size, size)
-		} else {
-			sizeDir = fmt.Sprintf("%d", size)
+			sizeDir = sizeDir + "x" + sizeDir
 		}
 		matchDir := ""
 		if joiner != "" {
@@ -389,7 +386,7 @@ func lookupIconPathInTheme(iconSize string, dir string, parentDir string, iconNa
 func fdoLookupIconPath(theme string, size int, iconName string) string {
 	locationLookup := fdoLookupXdgDataDirs()
 	iconTheme := theme
-	iconSize := fmt.Sprintf("%d", size)
+	iconSize := strconv.Itoa(size)
 	for _, dataDir := range locationLookup {
 		//Example is /usr/share/icons/icon_theme
 		dir := filepath.Join(dataDir, "icons", iconTheme)

--- a/internal/ui/desk.go
+++ b/internal/ui/desk.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"fmt"
 	"math"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -162,7 +162,7 @@ func (l *desktop) qtScreenScales() string {
 		}
 		// Qt toolkit cannot handle scale < 1
 		positiveScale := math.Max(1.0, float64(screen.CanvasScale()))
-		screenScales += fmt.Sprintf("%s=%1.1f", screen.Name, positiveScale)
+		screenScales += screen.Name + "=" + strconv.FormatFloat(positiveScale, 'f', 1, 32)
 	}
 	return screenScales
 }
@@ -171,9 +171,9 @@ func (l *desktop) scaleVars(scale float32) []string {
 	intScale := int(math.Round(float64(scale)))
 
 	return []string{
-		fmt.Sprintf("QT_SCREEN_SCALE_FACTORS=%s", l.qtScreenScales()),
-		fmt.Sprintf("GDK_SCALE=%d", intScale),
-		fmt.Sprintf("ELM_SCALE=%1.1f", scale),
+		"QT_SCREEN_SCALE_FACTORS=" + l.qtScreenScales(),
+		"GDK_SCALE=" + strconv.Itoa(intScale),
+		"ELM_SCALE=" + strconv.FormatFloat(float64(scale), 'f', 1, 32),
 	}
 }
 

--- a/internal/ui/settings_ui.go
+++ b/internal/ui/settings_ui.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -199,11 +198,11 @@ func (d *settingsUI) loadBarScreen() fyne.CanvasObject {
 
 	iconSize := widget.NewEntry()
 	iconSize.Wrapping = fyne.TextWrapOff
-	iconSize.SetText(fmt.Sprintf("%0.0f", d.settings.LauncherIconSize()))
+	iconSize.SetText(strconv.FormatFloat(float64(d.settings.LauncherIconSize()), 'f', 0, 32))
 
 	zoomScale := widget.NewEntry()
 	zoomScale.Wrapping = fyne.TextWrapOff
-	zoomScale.SetText(fmt.Sprintf("%0.2f", d.settings.LauncherZoomScale()))
+	zoomScale.SetText(strconv.FormatFloat(float64(d.settings.LauncherZoomScale()), 'f', 2, 64))
 
 	sizeCell := container.NewHBox(widget.NewLabel("Launcher Icon Size:"), iconSize)
 	zoomCell := container.NewHBox(widget.NewLabel("Launcher Zoom Scale:"), zoomScale)
@@ -331,15 +330,15 @@ func loadScreensTable() fyne.CanvasObject {
 	for _, screen := range fynedesk.Instance().Screens().Screens() {
 		names.Add(widget.NewLabelWithStyle(screen.Name, fyne.TextAlignLeading, fyne.TextStyle{Bold: true}))
 		labels1.Add(widget.NewLabel("Width"))
-		values1.Add(widget.NewLabel(fmt.Sprintf("%dpx", screen.Width)))
+		values1.Add(widget.NewLabel(strconv.Itoa(screen.Width) + "px"))
 		labels2.Add(widget.NewLabel("Height"))
-		values2.Add(widget.NewLabel(fmt.Sprintf("%dpx", screen.Height)))
+		values2.Add(widget.NewLabel(strconv.Itoa(screen.Height) + "px"))
 
 		names.Add(widget.NewLabel(""))
 		labels1.Add(widget.NewLabel("Scale"))
-		values1.Add(widget.NewLabel(fmt.Sprintf("%.1f", screen.Scale)))
+		values1.Add(widget.NewLabel(strconv.FormatFloat(float64(screen.Scale), 'f', 1, 32)))
 		labels2.Add(widget.NewLabel("Applied"))
-		values2.Add(widget.NewLabel(fmt.Sprintf("%.1f", screen.CanvasScale())))
+		values2.Add(widget.NewLabel(strconv.FormatFloat(float64(screen.CanvasScale()), 'f', 1, 32)))
 	}
 
 	return container.NewHBox(names, labels1, values1, labels2, values2)
@@ -356,7 +355,7 @@ func (d *settingsUI) loadScreensGroup() fyne.CanvasObject {
 	}
 
 	userScale := fyne.CurrentApp().Settings().Scale()
-	content := container.NewVBox(widget.NewLabel(fmt.Sprintf("User scale: %0.2f", userScale)))
+	content := container.NewVBox(widget.NewLabel("User scale: " + strconv.FormatFloat(float64(userScale), 'f', 2, 32)))
 	screens := widget.NewCard("Screens", "", container.NewVBox(displays, content, loadScreensTable()))
 	return screens
 }

--- a/internal/x11/wm/desk.go
+++ b/internal/x11/wm/desk.go
@@ -5,7 +5,6 @@ package wm // import "fyne.io/fynedesk/internal/x11/wm"
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"image"
 	"math"
 	"os"
@@ -701,7 +700,7 @@ func (x *x11WM) showWindow(win xproto.Window, parent xproto.Window) {
 }
 
 func (x *x11WM) takeSelectionOwnership() {
-	name := fmt.Sprintf("WM_S%d", x.x.Conn().DefaultScreen)
+	name := "WM_S" + strconv.Itoa(x.x.Conn().DefaultScreen)
 	selAtom, err := xprop.Atm(x.x, name)
 	if err != nil {
 		fyne.LogError("Error getting selection atom", err)

--- a/modules/status/brightness.go
+++ b/modules/status/brightness.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"errors"
-	"fmt"
 	"image/color"
 	"os/exec"
 	"strconv"
@@ -92,13 +91,13 @@ func (b *brightness) setValue(value int) {
 
 	switch b.mode {
 	case brightnessctl:
-		err := exec.Command("brightnessctl", "set", fmt.Sprintf("%d%%", value)).Run()
+		err := exec.Command("brightnessctl", "set", strconv.Itoa(value)+"%").Run()
 		if err != nil {
 			fyne.LogError("Error running brightnessctl", err)
 			return
 		}
 	default:
-		err := exec.Command("xbacklight", "-set", fmt.Sprintf("%d", value)).Run()
+		err := exec.Command("xbacklight", "-set", strconv.Itoa(value)).Run()
 		if err != nil {
 			fyne.LogError("Error running xbacklight", err)
 			return
@@ -216,8 +215,8 @@ func (i *brightItem) Icon() fyne.Resource {
 func (i *brightItem) Title() string {
 	if startsWith(i.input, "down") {
 		return "Brightness down"
-	} else if val, err := strconv.Atoi(i.input); err == nil {
-		return fmt.Sprintf("Brightness %d%%", val)
+	} else if _, err := strconv.Atoi(i.input); err == nil {
+		return "Brightness " + i.input + "%"
 	}
 
 	return "Brightness up"

--- a/modules/status/sound.go
+++ b/modules/status/sound.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -141,7 +140,7 @@ func (i *volItem) Title() string {
 	} else if startsWith(i.input, "down") {
 		return "Volume down"
 	} else if val, err := strconv.Atoi(i.input); err == nil {
-		return fmt.Sprintf("Volume %d%%", val)
+		return "Volume " + strconv.Itoa(val) + "%"
 	}
 
 	if i.s.muted() {

--- a/modules/status/sound.go
+++ b/modules/status/sound.go
@@ -139,8 +139,8 @@ func (i *volItem) Title() string {
 		return "Volume up"
 	} else if startsWith(i.input, "down") {
 		return "Volume down"
-	} else if val, err := strconv.Atoi(i.input); err == nil {
-		return "Volume " + strconv.Itoa(val) + "%"
+	} else if _, err := strconv.Atoi(i.input); err == nil {
+		return "Volume " + i.input + "%"
 	}
 
 	if i.s.muted() {

--- a/modules/status/sound_bsd.go
+++ b/modules/status/sound_bsd.go
@@ -53,7 +53,8 @@ func (b *sound) setup() error {
 }
 
 func (b *sound) setValue(vol int) {
-	level := fmt.Sprintf("%d:%d", vol, vol)
+	volStr := strconv.Itoa(vol)
+	level := vol + ":" + vol
 	cmd := exec.Command("mixer", "vol", level)
 	if err := cmd.Run(); err != nil {
 		fyne.LogError("Failed to set volume", err)

--- a/modules/status/sound_bsd.go
+++ b/modules/status/sound_bsd.go
@@ -3,7 +3,6 @@
 package status
 
 import (
-	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"


### PR DESCRIPTION
This switches to strconv where it is possible to do so without severely hurting readabilty and where it generally makes sense.
Performance and memory usage should generally be slightly better than before in these cases and there were even two cases for the sound module, where I managed to remove the convertions entirely.