### PR TITLE
Fix default position to middle not topleft

### DIFF
--- a/internal/x11/win/frame.go
+++ b/internal/x11/win/frame.go
@@ -463,7 +463,7 @@ func (f *frame) hide() {
 
 	borderWidth := x11.BorderWidth(x11.XWin(f.client))
 	titleHeight := x11.TitleHeight(x11.XWin(f.client))
-	x, y := f.x + int16(borderWidth), f.y + int16(titleHeight)
+	x, y := f.x+int16(borderWidth), f.y+int16(titleHeight)
 	xproto.ReparentWindow(f.client.wm.Conn(), f.client.win, f.client.wm.X().RootWin(), x, y)
 	xproto.UnmapWindow(f.client.wm.Conn(), f.client.win)
 }

--- a/wm/position.go
+++ b/wm/position.go
@@ -11,10 +11,10 @@ func PositionForNewWindow(x, y int, w, h uint, decorated bool,
 	screens fynedesk.ScreenList) (int, int, uint, uint) {
 
 	target := screens.Active()
-	offX, offY := 0, 0
+	offX, offY := (target.Width - int(w))/2, (target.Height - int(h))/2
 	if decorated {
-		offX = ScaleToPixels(theme.BorderWidth, target)
-		offY = ScaleToPixels(theme.TitleHeight, target)
+		offX -= ScaleToPixels(theme.BorderWidth, target)
+		offY -= ScaleToPixels(theme.TitleHeight, target)
 	}
 
 	return target.X + offX, target.Y + offY, w, h

--- a/wm/position.go
+++ b/wm/position.go
@@ -11,7 +11,7 @@ func PositionForNewWindow(x, y int, w, h uint, decorated bool,
 	screens fynedesk.ScreenList) (int, int, uint, uint) {
 
 	target := screens.Active()
-	offX, offY := (target.Width - int(w))/2, (target.Height - int(h))/2
+	offX, offY := (target.Width-int(w))/2, (target.Height-int(h))/2
 	if decorated {
 		offX -= ScaleToPixels(theme.BorderWidth, target)
 		offY -= ScaleToPixels(theme.TitleHeight, target)

--- a/wm/position_test.go
+++ b/wm/position_test.go
@@ -10,18 +10,18 @@ import (
 	"fyne.io/fynedesk/theme"
 )
 
-func TestPositionForNewWindow_TopLeft(t *testing.T) {
+func TestPositionForNewWindow_Default(t *testing.T) {
 	screen := &fynedesk.Screen{X: 50, Y: 0, Width: 500, Height: 500, Scale: 1}
 	x, y, _, _ := PositionForNewWindow(0, 0, 100, 100, true, test.NewScreensProvider(screen))
 
-	assert.Equal(t, 50+int(theme.BorderWidth), x)
-	assert.Equal(t, int(theme.TitleHeight), y)
+	assert.Equal(t, 250-int(theme.BorderWidth), x)
+	assert.Equal(t, 200-int(theme.TitleHeight), y)
 }
 
-func TestPositionForNewWindow_TopLeftBorderless(t *testing.T) {
+func TestPositionForNewWindow_DefaultBorderless(t *testing.T) {
 	screen := &fynedesk.Screen{X: 50, Y: 0, Width: 500, Height: 500, Scale: 1}
 	x, y, _, _ := PositionForNewWindow(0, 0, 100, 100, false, test.NewScreensProvider(screen))
 
-	assert.Equal(t, 50, x)
-	assert.Equal(t, 0, y)
+	assert.Equal(t, 250, x)
+	assert.Equal(t, 200, y)
 }


### PR DESCRIPTION
When a window has no specified position the top left is not most helpful, move to middle for now (smarter algorithms could be added later).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

