### PR TITLE
Position windows that are transient inside their parent

### DIFF
--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -255,6 +255,20 @@ func (c *client) NotifyUnMaximize() {
 	x11.WindowExtendedHintsRemove(c.wm.X(), c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
 }
 
+func (c *client) Parent() fynedesk.Window {
+	id := x11.WindowTransientForGet(c.wm.X(), c.win)
+	if id == 0 {
+		return nil
+	}
+
+	for _, win := range c.wm.Windows() {
+		if win.(x11.XWin).ChildID() == id {
+			return win
+		}
+	}
+	return nil
+}
+
 func (c *client) Position() fyne.Position {
 	screen := fynedesk.Instance().Screens().ScreenForWindow(c)
 
@@ -378,7 +392,7 @@ func (c *client) positionNewWindow() {
 		y = primary.Height - int(h)
 	} else if (!requestPosition && !hasPosition) || !c.positionIsValid(x, y) {
 		decorated := !windowBorderless(c.wm.X(), c.win)
-		x, y, w, h = wm.PositionForNewWindow(int(attrs.X), int(attrs.Y), uint(attrs.Width), uint(attrs.Height),
+		x, y, w, h = wm.PositionForNewWindow(c, int(attrs.X), int(attrs.Y), uint(attrs.Width), uint(attrs.Height),
 			decorated, fynedesk.Instance().Screens())
 	}
 

--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -379,7 +379,7 @@ func (c *client) positionNewWindow() {
 	requestPosition := false
 	hints, err := icccm.WmNormalHintsGet(c.wm.X(), c.win)
 	if err == nil {
-		if hints.Flags&icccm.SizeHintPPosition != 0 || hints.Flags&icccm.SizeHintUSPosition != 0 {
+		if (hints.Flags&icccm.SizeHintPPosition != 0 || hints.Flags&icccm.SizeHintUSPosition != 0) && c.Parent() == nil {
 			requestPosition = true
 		}
 	}

--- a/test/window.go
+++ b/test/window.go
@@ -71,6 +71,7 @@ func (w *Window) Maximized() bool {
 	return false
 }
 
+// Parent returns a window that this should be positioned within, if set.
 func (w *Window) Parent() fynedesk.Window {
 	return nil
 }

--- a/test/window.go
+++ b/test/window.go
@@ -12,11 +12,15 @@ type Window struct {
 	props dummyProperties
 
 	iconic, focused, fullscreen, maximized, raised bool
+
+	parent        fynedesk.Window
+	x, y          int
+	width, height uint
 }
 
 // NewWindow creates a virtual window with the given title ("" is acceptable)
 func NewWindow(title string) *Window {
-	win := &Window{}
+	win := &Window{width: 10, height: 10}
 	win.props.name = title
 	return win
 }
@@ -73,7 +77,7 @@ func (w *Window) Maximized() bool {
 
 // Parent returns a window that this should be positioned within, if set.
 func (w *Window) Parent() fynedesk.Window {
-	return nil
+	return w.parent
 }
 
 // Position returns 0, 0 for test windows
@@ -109,6 +113,17 @@ func (w *Window) SetCommand(cmd string) {
 // SetIconName is a test utility to set the icon-name property of this window
 func (w *Window) SetIconName(name string) {
 	w.props.iconName = name
+}
+
+// SetGeometry is a test utility to set the position and size of this window
+func (w *Window) SetGeometry(x, y int, width, height uint) {
+	w.x, w.y = x, y
+	w.width, w.height = width, height
+}
+
+// SetParent is a test utility to set a parent of this window
+func (w *Window) SetParent(p fynedesk.Window) {
+	w.parent = p
 }
 
 // TopWindow returns true if this window has been raised above all others

--- a/test/window.go
+++ b/test/window.go
@@ -71,6 +71,10 @@ func (w *Window) Maximized() bool {
 	return false
 }
 
+func (w *Window) Parent() fynedesk.Window {
+	return nil
+}
+
 // Position returns 0, 0 for test windows
 func (w *Window) Position() fyne.Position {
 	return fyne.NewPos(0, 0)

--- a/test/window_x11.go
+++ b/test/window_x11.go
@@ -21,7 +21,7 @@ func (w *Window) FrameID() xproto.Window {
 
 // Geometry returns the x, y position and width, height size of this window's outer bounds
 func (w *Window) Geometry() (int, int, uint, uint) {
-	return 0, 0, 10, 10
+	return w.x, w.y, w.width, w.height
 }
 
 // NotifyBorderChange is called when the border should be shown or hidden

--- a/window.go
+++ b/window.go
@@ -27,6 +27,7 @@ type Window interface {
 	Uniconify()           // Request to restore this window and possibly children of this window from being minimized
 	Unmaximize()          // Request to restore this window to its size before being maximized
 
+	Parent() Window
 	Properties() WindowProperties // Request the properties set on this window
 	Position() fyne.Position
 }

--- a/wm/position.go
+++ b/wm/position.go
@@ -7,15 +7,26 @@ import (
 
 // PositionForNewWindow returns the suggested position for a new window of the given geometry.
 // The screen list hints at available space, but normally list.Active() is the best.
-func PositionForNewWindow(x, y int, w, h uint, decorated bool,
+func PositionForNewWindow(win fynedesk.Window, x, y int, w, h uint, decorated bool,
 	screens fynedesk.ScreenList) (int, int, uint, uint) {
 
 	target := screens.Active()
-	offX, offY := (target.Width-int(w))/2, (target.Height-int(h))/2
+	var offX, offY int
+	parent := win.Parent()
+	if parent != nil {
+		wx, wy, ww, wh := parent.(interface{ Geometry() (int, int, uint, uint) }).Geometry() // avoid XWin import cycle
+		offX, offY = positionInRect(w, h, wx, wy, ww, wh)
+	} else {
+		offX, offY = positionInRect(w, h, target.X, target.Y, uint(target.Width), uint(target.Height))
+	}
 	if decorated {
 		offX -= ScaleToPixels(theme.BorderWidth, target)
 		offY -= ScaleToPixels(theme.TitleHeight, target)
 	}
 
 	return target.X + offX, target.Y + offY, w, h
+}
+
+func positionInRect(ww, hh uint, x, y int, w, h uint) (int, int) {
+	return x + (int(w)-int(ww))/2, y + (int(h)-int(hh))/2
 }

--- a/wm/position.go
+++ b/wm/position.go
@@ -24,7 +24,7 @@ func PositionForNewWindow(win fynedesk.Window, x, y int, w, h uint, decorated bo
 		offY -= ScaleToPixels(theme.TitleHeight, target)
 	}
 
-	return target.X + offX, target.Y + offY, w, h
+	return offX, offY, w, h
 }
 
 func positionInRect(ww, hh uint, x, y int, w, h uint) (int, int) {

--- a/wm/position_test.go
+++ b/wm/position_test.go
@@ -11,16 +11,18 @@ import (
 )
 
 func TestPositionForNewWindow_Default(t *testing.T) {
+	w := test.NewWindow("Hi")
 	screen := &fynedesk.Screen{X: 50, Y: 0, Width: 500, Height: 500, Scale: 1}
-	x, y, _, _ := PositionForNewWindow(0, 0, 100, 100, true, test.NewScreensProvider(screen))
+	x, y, _, _ := PositionForNewWindow(w, 0, 0, 100, 100, true, test.NewScreensProvider(screen))
 
 	assert.Equal(t, 250-int(theme.BorderWidth), x)
 	assert.Equal(t, 200-int(theme.TitleHeight), y)
 }
 
 func TestPositionForNewWindow_DefaultBorderless(t *testing.T) {
+	w := test.NewWindow("Hi")
 	screen := &fynedesk.Screen{X: 50, Y: 0, Width: 500, Height: 500, Scale: 1}
-	x, y, _, _ := PositionForNewWindow(0, 0, 100, 100, false, test.NewScreensProvider(screen))
+	x, y, _, _ := PositionForNewWindow(w, 0, 0, 100, 100, false, test.NewScreensProvider(screen))
 
 	assert.Equal(t, 250, x)
 	assert.Equal(t, 200, y)

--- a/wm/position_test.go
+++ b/wm/position_test.go
@@ -27,3 +27,24 @@ func TestPositionForNewWindow_DefaultBorderless(t *testing.T) {
 	assert.Equal(t, 250, x)
 	assert.Equal(t, 200, y)
 }
+
+func TestPositionForNewWindow_WithParent(t *testing.T) {
+	parent := test.NewWindow("Parent")
+	parent.SetGeometry(200, 100, 400, 200)
+
+	w := test.NewWindow("Child")
+	w.SetParent(parent)
+
+	screen := &fynedesk.Screen{X: 50, Y: 0, Width: 500, Height: 500, Scale: 1}
+	x, y, _, _ := PositionForNewWindow(w, 0, 0, 100, 100, false, test.NewScreensProvider(screen))
+
+	assert.Equal(t, 350, x)
+	assert.Equal(t, 150, y)
+
+	// move up/left by 100,100
+	parent.SetGeometry(100, 0, 400, 200)
+	x, y, _, _ = PositionForNewWindow(w, 0, 0, 100, 100, false, test.NewScreensProvider(screen))
+
+	assert.Equal(t, 250, x)
+	assert.Equal(t, 50, y)
+}


### PR DESCRIPTION
This also fixes positioning of windows inside active screen when not top/left monitor

Fixes #48

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
