### PR TITLE
Forcing vsync to be enabled by default

### DIFF
--- a/modules/composit/compton.go
+++ b/modules/composit/compton.go
@@ -34,7 +34,7 @@ func (c *comp) enable() {
 		return
 	}
 
-	_ = exec.Command(path, "-c", "-C", "-r", "20", "-f", "-i", "1.0").Start()
+	_ = exec.Command(path, "--vsync", "drm", "-c", "-C", "-r", "20", "-f", "-i", "1.0").Start()
 }
 
 // newCompiz creates a new module that will manage composition of the windows.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes screen tearing on OpenBSD (tested: 7.2-beta, amdgpu) and potentially on other platforms, by forcing compton to use drm as vsync method.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

